### PR TITLE
meta: prepare repo for uutils ecosystem integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
 
   test-docker:
     name: Test (${{ matrix.target }})
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: EmbarkStudios/cargo-deny-action@v2
+
+  test-docker:
+    name: Test (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [debian, alpine, fedora]
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose run --rm ${{ matrix.target }} cargo test --workspace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ everything you need to know.
 
 Before you start, also check:
 
-- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) (when created)
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
 - [SECURITY.md](./SECURITY.md) for vulnerability reporting
 
 > [!WARNING]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "Memory-safe Rust reimplementation of Linux shadow-utils"
 readme = "README.md"
 keywords = ["shadow-utils", "uutils", "shadow", "passwd", "linux"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,15 @@
 [package]
 name = "shadow-rs"
 version = "0.0.1"
-edition = "2021"
-license = "MIT"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
 description = "Memory-safe Rust reimplementation of Linux shadow-utils"
-repository = "https://github.com/shadow-utils-rs/shadow-rs"
 readme = "README.md"
-keywords = ["coreutils", "shadow", "passwd", "useradd", "linux"]
-categories = ["command-line-utilities", "os::unix-apis"]
+keywords = ["shadow-utils", "uutils", "shadow", "passwd", "linux"]
+categories = ["command-line-utilities"]
 
 [workspace]
 members = [
@@ -37,6 +39,9 @@ rust-version = "1.94.0"
 license = "MIT"
 authors = ["shadow-rs contributors"]
 repository = "https://github.com/shadow-utils-rs/shadow-rs"
+homepage = "https://github.com/shadow-utils-rs/shadow-rs"
+keywords = ["shadow-utils", "uutils", "shadow", "passwd", "linux"]
+categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Internal crates
@@ -109,6 +114,7 @@ feat_phase1 = ["feat_passwd", "feat_pwck"]
 feat_phase2 = ["feat_useradd", "feat_userdel", "feat_usermod", "feat_chpasswd", "feat_chage"]
 feat_phase3 = ["feat_groupadd", "feat_groupdel", "feat_groupmod", "feat_grpck", "feat_chfn", "feat_chsh", "feat_newgrp"]
 feat_common = ["feat_phase1", "feat_phase2"]
+feat_common_core = ["feat_phase1", "feat_phase2", "feat_phase3"]
 
 # PAM authentication (requires libpam-dev)
 pam = ["passwd/pam"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 # shadow-rs
 
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/shadow-utils-rs/shadow-rs/blob/main/LICENSE)
+[![CI](https://github.com/shadow-utils-rs/shadow-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/shadow-utils-rs/shadow-rs/actions/workflows/ci.yml)
+[![MSRV](https://img.shields.io/badge/MSRV-1.94.0-blue)](https://github.com/shadow-utils-rs/shadow-rs)
 
 </div>
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -16,8 +16,8 @@
 //! Supported shells: bash, zsh, fish, elvish, powershell
 
 use clap::{Arg, ArgAction, Command};
-use clap_complete::generate;
 use clap_complete::Shell;
+use clap_complete::generate;
 use std::io;
 
 fn get_tool_app(name: &str) -> Option<Command> {

--- a/src/shadow-core/Cargo.toml
+++ b/src/shadow-core/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Core library for shadow-rs: parsers, atomic file ops, locking, PAM integration"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "shadow-core ~ (shadow-rs) parsers, atomic file ops, locking, PAM"
 
 [lib]
 path = "src/lib.rs"

--- a/src/uu/chage/Cargo.toml
+++ b/src/uu/chage/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "chage command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "chage ~ (shadow-rs) change user password aging"
 
 [lib]
 path = "src/chage.rs"

--- a/src/uu/chfn/Cargo.toml
+++ b/src/uu/chfn/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "chfn command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "chfn ~ (shadow-rs) change user finger information"
 
 [lib]
 path = "src/chfn.rs"

--- a/src/uu/chpasswd/Cargo.toml
+++ b/src/uu/chpasswd/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "chpasswd command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "chpasswd ~ (shadow-rs) update passwords in batch"
 
 [lib]
 path = "src/chpasswd.rs"

--- a/src/uu/chsh/Cargo.toml
+++ b/src/uu/chsh/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "chsh command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "chsh ~ (shadow-rs) change user login shell"
 
 [lib]
 path = "src/chsh.rs"

--- a/src/uu/groupadd/Cargo.toml
+++ b/src/uu/groupadd/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "groupadd command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "groupadd ~ (shadow-rs) create a new group"
 
 [lib]
 path = "src/groupadd.rs"

--- a/src/uu/groupdel/Cargo.toml
+++ b/src/uu/groupdel/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "groupdel command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "groupdel ~ (shadow-rs) delete a group"
 
 [lib]
 path = "src/groupdel.rs"

--- a/src/uu/groupmod/Cargo.toml
+++ b/src/uu/groupmod/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "groupmod command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "groupmod ~ (shadow-rs) modify a group"
 
 [lib]
 path = "src/groupmod.rs"

--- a/src/uu/grpck/Cargo.toml
+++ b/src/uu/grpck/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "grpck command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "grpck ~ (shadow-rs) verify integrity of group files"
 
 [lib]
 path = "src/grpck.rs"

--- a/src/uu/newgrp/Cargo.toml
+++ b/src/uu/newgrp/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "newgrp command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "newgrp ~ (shadow-rs) change effective group ID"
 
 [lib]
 path = "src/newgrp.rs"

--- a/src/uu/passwd/Cargo.toml
+++ b/src/uu/passwd/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "passwd command — change user password (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "passwd ~ (shadow-rs) change user password"
 
 [lib]
 path = "src/passwd.rs"

--- a/src/uu/pwck/Cargo.toml
+++ b/src/uu/pwck/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "pwck command — verify integrity of password files (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "pwck ~ (shadow-rs) verify integrity of password files"
 
 [lib]
 path = "src/pwck.rs"

--- a/src/uu/useradd/Cargo.toml
+++ b/src/uu/useradd/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "useradd command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "useradd ~ (shadow-rs) create a new user"
 
 [lib]
 path = "src/useradd.rs"

--- a/src/uu/userdel/Cargo.toml
+++ b/src/uu/userdel/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "userdel command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "userdel ~ (shadow-rs) delete a user account"
 
 [lib]
 path = "src/userdel.rs"

--- a/src/uu/usermod/Cargo.toml
+++ b/src/uu/usermod/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "usermod command (shadow-rs)"
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "usermod ~ (shadow-rs) modify a user account"
 
 [lib]
 path = "src/usermod.rs"

--- a/tests/by-util/test_passwd.rs
+++ b/tests/by-util/test_passwd.rs
@@ -428,15 +428,15 @@ fn test_gnu_compat_status_output() {
 
     // Verify our format matches by parsing a shadow entry and formatting it
     let shadow_path = std::path::Path::new("/etc/shadow");
-    if let Ok(entries) = shadow_core::shadow::read_shadow_file(shadow_path) {
-        if let Some(entry) = entries.iter().find(|e| e.name == "root") {
-            let our_status = entry.status_char();
-            assert_eq!(
-                our_status, gnu_fields[1],
-                "status char mismatch: ours={our_status}, GNU={}",
-                gnu_fields[1]
-            );
-        }
+    if let Ok(entries) = shadow_core::shadow::read_shadow_file(shadow_path)
+        && let Some(entry) = entries.iter().find(|e| e.name == "root")
+    {
+        let our_status = entry.status_char();
+        assert_eq!(
+            our_status, gnu_fields[1],
+            "status char mismatch: ours={our_status}, GNU={}",
+            gnu_fields[1]
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Aligns repository metadata, docs, and CI with uutils ecosystem conventions in preparation for integration discussions with Sylvestre Ledru (uutils maintainer).

- **Cargo.toml metadata**: Fix edition inconsistency (2021 → 2024), fix keywords (`coreutils` → `shadow-utils`), add `homepage`/`keywords`/`categories` to workspace, add workspace inheritance to all 15 crate Cargo.toml files, normalize descriptions to `"tool ~ (shadow-rs) verb phrase"` format, add `feat_common_core` feature alias
- **README.md**: Add CI and MSRV badges
- **CONTRIBUTING.md**: Fix stale `(when created)` reference to CODE_OF_CONDUCT.md
- **CI**: Add Docker multi-distro test matrix (debian/alpine/fedora) to GitHub Actions
- **New files**: `renovate.json` (automated dependency updates), `rust-toolchain.toml` (contributor convenience)
- Fix pre-existing clippy (`collapsible_if`) and fmt (edition 2024 import ordering) issues

No functional code changes. Zero impact on behavior or tests.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes on all 3 distros (debian, alpine, fedora)