### PR TITLE
make install: default to standalone per-tool binaries (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cargo.toml metadata aligned with uutils ecosystem conventions
 - Tool crate descriptions normalized to `"tool ~ (shadow-rs) verb phrase"` format
 - Edition 2024 consistently applied across root and workspace packages
+- `make install` now defaults to 14 standalone per-tool binaries with
+  least-privilege setuid layout matching GNU shadow-utils (#138). Only
+  `passwd`/`chfn`/`chsh`/`newgrp` are setuid-root; the other 10 are `0755`.
+  The previous multicall install is available as `make install-multicall`.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/sbin
-PROFILE ?= release
 
 # Tools that need setuid-root to allow non-root callers (change own password,
 # GECOS, shell, effective group).
@@ -17,10 +16,10 @@ ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS)
 all: build
 
 build:
-	cargo build --profile $(PROFILE) --workspace --bins --exclude shadow-rs
+	cargo build --release --workspace --bins --exclude shadow-rs
 
 build-multicall:
-	cargo build --profile $(PROFILE) --bin shadow-rs
+	cargo build --release --bin shadow-rs
 
 test:
 	cargo test --workspace
@@ -29,21 +28,21 @@ test:
 # layout matching GNU shadow-utils. Only passwd/chfn/chsh/newgrp are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \
-		install -Dm4755 target/$(PROFILE)/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
+		install -Dm4755 target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
 	done
 	@for tool in $(ROOT_TOOLS); do \
-		install -Dm0755 target/$(PROFILE)/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
+		install -Dm0755 target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
 	done
 	@echo "Installed $(words $(ALL_TOOLS)) standalone binaries to $(DESTDIR)$(BINDIR)/"
 	@echo "  setuid (4755): $(SETUID_TOOLS)"
 	@echo "  root-only (0755): $(ROOT_TOOLS)"
 
 # Opt-in install: single multicall binary with symlinks. Smaller footprint but
-# larger setuid attack surface — chmod on any setuid symlink follows through to
-# the ELF, so all tools end up running with euid=root. Intended for
+# larger setuid attack surface — the binary is installed setuid-root, so all 14
+# applets run with euid=root when invoked via symlink. Intended for
 # container/embedded use where disk savings matter and attack surface does not.
 install-multicall: build-multicall
-	install -Dm4755 target/$(PROFILE)/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
+	install -Dm4755 target/release/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
 	@for tool in $(ALL_TOOLS); do \
 		ln -sf shadow-rs $(DESTDIR)$(BINDIR)/$$tool; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,7 @@ ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS)
 all: build
 
 build:
-	@for tool in $(ALL_TOOLS); do \
-		cargo build --profile $(PROFILE) -p uu_$$tool --bin $$tool || exit 1; \
-	done
+	cargo build --profile $(PROFILE) --workspace --bins --exclude shadow-rs
 
 build-multicall:
 	cargo build --profile $(PROFILE) --bin shadow-rs
@@ -30,11 +28,11 @@ test:
 # Default install: 14 standalone per-tool binaries with least-privilege setuid
 # layout matching GNU shadow-utils. Only passwd/chfn/chsh/newgrp are setuid.
 install: build
-	@for tool in $(ALL_TOOLS); do \
-		install -Dm755 target/$(PROFILE)/$$tool $(DESTDIR)$(BINDIR)/$$tool; \
-	done
 	@for tool in $(SETUID_TOOLS); do \
-		chmod 4755 $(DESTDIR)$(BINDIR)/$$tool 2>/dev/null || true; \
+		install -Dm4755 target/$(PROFILE)/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
+	done
+	@for tool in $(ROOT_TOOLS); do \
+		install -Dm0755 target/$(PROFILE)/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
 	done
 	@echo "Installed $(words $(ALL_TOOLS)) standalone binaries to $(DESTDIR)$(BINDIR)/"
 	@echo "  setuid (4755): $(SETUID_TOOLS)"
@@ -45,12 +43,9 @@ install: build
 # the ELF, so all tools end up running with euid=root. Intended for
 # container/embedded use where disk savings matter and attack surface does not.
 install-multicall: build-multicall
-	install -Dm755 target/$(PROFILE)/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
+	install -Dm4755 target/$(PROFILE)/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
 	@for tool in $(ALL_TOOLS); do \
 		ln -sf shadow-rs $(DESTDIR)$(BINDIR)/$$tool; \
-	done
-	@for tool in $(SETUID_TOOLS); do \
-		chmod 4755 $(DESTDIR)$(BINDIR)/$$tool 2>/dev/null || true; \
 	done
 	@echo "Installed multicall shadow-rs + $(words $(ALL_TOOLS)) symlinks to $(DESTDIR)$(BINDIR)/"
 

--- a/Makefile
+++ b/Makefile
@@ -2,34 +2,60 @@ PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/sbin
 PROFILE ?= release
 
-TOOLS = passwd pwck useradd userdel usermod chpasswd chage \
-        groupadd groupdel groupmod grpck chfn chsh newgrp
+# Tools that need setuid-root to allow non-root callers (change own password,
+# GECOS, shell, effective group).
+SETUID_TOOLS = passwd chfn chsh newgrp
 
-.PHONY: all build test install uninstall clean
+# Root-only tools (no setuid; fail at getuid() check for non-root callers).
+ROOT_TOOLS = useradd userdel usermod chpasswd chage \
+             groupadd groupdel groupmod pwck grpck
+
+ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS)
+
+.PHONY: all build build-multicall test install install-multicall uninstall clean
 
 all: build
 
 build:
-	cargo build --profile $(PROFILE)
+	@for tool in $(ALL_TOOLS); do \
+		cargo build --profile $(PROFILE) -p uu_$$tool --bin $$tool || exit 1; \
+	done
+
+build-multicall:
+	cargo build --profile $(PROFILE) --bin shadow-rs
 
 test:
 	cargo test --workspace
 
+# Default install: 14 standalone per-tool binaries with least-privilege setuid
+# layout matching GNU shadow-utils. Only passwd/chfn/chsh/newgrp are setuid.
 install: build
-	install -Dm755 target/$(PROFILE)/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
-	@for tool in $(TOOLS); do \
-		ln -sf shadow-rs $(DESTDIR)$(BINDIR)/$$tool; \
+	@for tool in $(ALL_TOOLS); do \
+		install -Dm755 target/$(PROFILE)/$$tool $(DESTDIR)$(BINDIR)/$$tool; \
 	done
-	@# Setuid-root for tools that need it. chmod on symlinks affects the
-	@# underlying multicall binary — this is intentional for drop-in
-	@# replacement since all traditional shadow-utils tools are setuid-root.
-	@for tool in passwd chfn chsh newgrp; do \
+	@for tool in $(SETUID_TOOLS); do \
 		chmod 4755 $(DESTDIR)$(BINDIR)/$$tool 2>/dev/null || true; \
 	done
-	@echo "Installed shadow-rs + $(words $(TOOLS)) symlinks to $(DESTDIR)$(BINDIR)/"
+	@echo "Installed $(words $(ALL_TOOLS)) standalone binaries to $(DESTDIR)$(BINDIR)/"
+	@echo "  setuid (4755): $(SETUID_TOOLS)"
+	@echo "  root-only (0755): $(ROOT_TOOLS)"
+
+# Opt-in install: single multicall binary with symlinks. Smaller footprint but
+# larger setuid attack surface — chmod on any setuid symlink follows through to
+# the ELF, so all tools end up running with euid=root. Intended for
+# container/embedded use where disk savings matter and attack surface does not.
+install-multicall: build-multicall
+	install -Dm755 target/$(PROFILE)/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
+	@for tool in $(ALL_TOOLS); do \
+		ln -sf shadow-rs $(DESTDIR)$(BINDIR)/$$tool; \
+	done
+	@for tool in $(SETUID_TOOLS); do \
+		chmod 4755 $(DESTDIR)$(BINDIR)/$$tool 2>/dev/null || true; \
+	done
+	@echo "Installed multicall shadow-rs + $(words $(ALL_TOOLS)) symlinks to $(DESTDIR)$(BINDIR)/"
 
 uninstall:
-	@for tool in $(TOOLS); do \
+	@for tool in $(ALL_TOOLS); do \
 		rm -f $(DESTDIR)$(BINDIR)/$$tool; \
 	done
 	rm -f $(DESTDIR)$(BINDIR)/shadow-rs

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ sudo make install PREFIX=/usr/local
 ```
 
 Alternative: single multicall binary with symlinks. Smaller footprint (~14×
-disk savings) but larger setuid attack surface, since `chmod` on a setuid
-symlink follows through to the underlying ELF — all 14 tools end up running
-with `euid=root` when invoked. Intended for container/embedded use cases.
+disk savings) but larger setuid attack surface — the binary is installed
+setuid-root, so all 14 applets run with `euid=root` when invoked via symlink.
+Intended for container/embedded use cases.
 
 ```shell
 sudo make install-multicall PREFIX=/usr/local

--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ docker compose build debian
 docker compose run --rm debian cargo build --release
 ```
 
+### Install
+
+Default install: 14 standalone per-tool binaries with least-privilege setuid
+layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp` are
+installed setuid-root; the other 10 are plain `0755`.
+
+```shell
+sudo make install PREFIX=/usr/local
+```
+
+Alternative: single multicall binary with symlinks. Smaller footprint (~14×
+disk savings) but larger setuid attack surface, since `chmod` on a setuid
+symlink follows through to the underlying ELF — all 14 tools end up running
+with `euid=root` when invoked. Intended for container/embedded use cases.
+
+```shell
+sudo make install-multicall PREFIX=/usr/local
+```
+
 ### Test
 
 All builds and tests run inside Docker containers to isolate from the host


### PR DESCRIPTION
## Summary

Switch the default `make install` to build and install 14 standalone per-tool binaries with a least-privilege setuid layout matching GNU shadow-utils. Raised by @oech3 in [uutils/coreutils#11828](https://github.com/uutils/coreutils/issues/11828).

Fixes #138.

### The problem

The old layout installed one multicall `shadow-rs` binary with 14 symlinks, then `chmod 4755` on the `passwd`/`chfn`/`chsh`/`newgrp` symlinks. Because `chmod` on a symlink follows through to the ELF target, the underlying binary ended up setuid root — so `useradd`, `usermod`, `userdel`, etc. all ran with \`euid=0\` when invoked via symlink. Each tool's internal \`getuid() == 0\` check was defense-in-depth, not OS-level least privilege.

### The fix

\`make install\` now builds each tool as its own binary (each crate already has a \`[[bin]]\` entry) and installs them individually:

- \`4755\` setuid: \`passwd\`, \`chfn\`, \`chsh\`, \`newgrp\` (4 tools)
- \`0755\` root-only: \`useradd\`, \`userdel\`, \`usermod\`, \`chpasswd\`, \`chage\`, \`groupadd\`, \`groupdel\`, \`groupmod\`, \`pwck\`, \`grpck\` (10 tools)

This matches GNU shadow-utils' install layout exactly.

The previous multicall install is preserved as \`make install-multicall\` for container/embedded use cases where the ~14× disk savings matter and the enlarged setuid attack surface is acceptable.

## Test plan

Verified in Docker (debian image):

- [x] \`make build\` produces all 14 binaries in \`target/release/\`
- [x] \`make install DESTDIR=/tmp/test\` installs 14 files with correct modes: \`4755\` on passwd/chfn/chsh/newgrp, \`0755\` on the other 10
- [x] \`make install-multicall DESTDIR=/tmp/test\` installs 1 binary + 14 symlinks with shadow-rs binary at \`4755\`
- [x] \`make uninstall\` removes all files in both layouts (14 installed → 0 after uninstall)
- [x] \`cargo fmt --check\` and \`cargo clippy -- -D warnings\` still clean (no Rust changes)
- [x] Pre-push hook: full test suite on debian/alpine/fedora all pass