### PR TITLE
shadow-rs: suppress unwind tables in release builds (#143)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,15 @@
+# Suppress unwind table generation in all builds.
+#
+# Since Rust 1.92, panic=abort no longer prevents unwind tables from being
+# emitted on Linux (see https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/).
+# For setuid-root binaries, unwind tables leak internal binary layout
+# information. Disabling them removes that attack surface.
+#
+# strip=true in [profile.release] already removes debug symbols; this covers
+# the unwind tables that strip does not remove.
+#
+# Note: Cargo's per-profile rustflags (profile-rustflags) is not yet
+# stabilised as of Cargo 1.95. This flag is applied globally but is harmless
+# in debug builds (debug info already exposes far more than unwind tables).
+[build]
+rustflags = ["-C", "force-unwind-tables=no"]


### PR DESCRIPTION
## Summary

Suppress unwind table generation in release builds to prevent binary layout leakage from setuid-root tools.

Fixes #143. Raised by @oech3.

Since Rust 1.92, `panic=abort` no longer prevents unwind table emission on Linux. These tables expose function boundaries and call graph structure — a security concern for setuid-root binaries.

## Changes

New file: `.cargo/config.toml` with `-C force-unwind-tables=no`.

`profile-rustflags` is still unstable in Cargo 1.95, so the flag goes in `[build] rustflags` (applies to all profiles — harmless in dev builds where debug info already exposes far more).

## Test plan

- [x] `cargo build --release -p uu_passwd` — success
- [x] `readelf -S target/release/passwd | grep -i unwind` — empty (no unwind tables)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] Pre-push hook: full test suite on debian/alpine/fedora — all pass