### PR TITLE
docs: backfill CHANGELOG and SECURITY-HARDENING for review rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `passwd`/`chfn`/`chsh`/`newgrp` are setuid-root; the other 10 are `0755`.
   The previous multicall install is available as `make install-multicall`.
 
+### Security
+
+- PAM password buffers zeroed immediately after use (`zeroize`)
+- `initgroups()` called in newgrp before exec (prevents supplementary group leak)
+- `SignalBlocker` scoped to file-mutation critical sections only; dropped before
+  long-running operations (home deletion, recursive chown, skel copy)
+- `UmaskGuard` marked `!Send`/`!Sync` via `PhantomData<Rc<()>>` (thread-safety)
+- `newgrp` uses targeted hardening (`suppress_core_dumps` + `sanitized_env`)
+  instead of `harden_process()` to avoid leaking `RLIMIT_FSIZE` to exec'd shell
+- `atomic_write` retries once on stale temp file from prior crash
+- `crypt(3)` wrapper documented as non-thread-safe (uses global state)
+- Centralized hardening utilities in `shadow_core::hardening` (deduplicated
+  from per-tool copies)
+- `println!`/`eprintln!` replaced with non-panicking writes (#141)
+- Unwind tables suppressed in release builds (`-C force-unwind-tables=no`, #143)
+
 ### Fixed
 
 - Password hash validation rejects `:`, `\n`, `\r` (field injection prevention)
@@ -55,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recursive chown on UID change (usermod)
 - Proper date validation with leap year and month-length rules
 - GNU-compatible output and exit codes for all tools
-- 460+ unit tests, property-based tests (proptest), 4 fuzz targets
+- 580+ unit tests, property-based tests (proptest), 6 fuzz targets
 - Integration tests for 14 tools
 - Docker test matrix: Debian (glibc), Alpine (musl), Fedora (SELinux)
 - CI gates: fmt, clippy, test, MSRV (1.94.0), cargo-deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Centralized hardening utilities in `shadow_core::hardening` (deduplicated
   from per-tool copies)
 - `println!`/`eprintln!` replaced with non-panicking writes (#141)
-- Unwind tables suppressed in release builds (`-C force-unwind-tables=no`, #143)
+- Unwind tables suppressed via `-C force-unwind-tables=no` (#143)
 
 ### Fixed
 

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -25,6 +25,13 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
 - [x] O_CLOEXEC on file descriptors (#50)
 - [x] Umask reset (#51 — `UmaskGuard` RAII)
 - [x] Landlock filesystem restriction (#41 — `apply_landlock()` in passwd)
+- [x] PAM password buffer zeroization (immediate `zeroize` after use)
+- [x] `initgroups()` in newgrp (prevent supplementary group leak across exec)
+- [x] `UmaskGuard` `!Send`/`!Sync` (`PhantomData<Rc<()>>` — prevent cross-thread umask corruption)
+- [x] `atomic_write` retry on stale temp file from prior crash
+- [x] `SignalBlocker` scoped to critical sections only (dropped before long-running ops)
+- [x] Centralized hardening in `shadow_core::hardening` (deduplicated across tools)
+- [x] Targeted hardening in newgrp (no `RLIMIT_FSIZE` leak to exec'd shell)
 
 ## Not Yet Implemented
 


### PR DESCRIPTION
## Summary

Backfill documentation that was deferred across multiple PRs:

- **CHANGELOG [Unreleased]**: add Security section with all review round 2 fixes (PAM zeroization, initgroups, SignalBlocker scoping, UmaskGuard !Send/!Sync, targeted newgrp hardening, atomic_write retry, crypt thread-safety docs, centralized hardening, println panic fix #141, unwind table suppression #143)
- **CHANGELOG [0.1.0]**: update test count 460+ → 580+, fuzz targets 4 → 6
- **SECURITY-HARDENING.md**: add 7 implemented items from review round 2

## Test plan

- [x] No code changes — docs only
- [x] Pre-push hook passed all 3 distros