### PR TITLE
chore: gitignore AI review artifacts under docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /fuzz/Cargo.lock
 CLAUDE.md
 PLAN-shadow-rs.md
+docs/claude-review-*.md
+docs/gemini-review-*.txt


### PR DESCRIPTION
Local review exports (`docs/claude-review-*.md`, `docs/gemini-review-*.txt`) are working scratch and should never be committed. Only `CLAUDE.md` and `PLAN-shadow-rs.md` were ignored, so these slipped through `git add -A`. Add the two patterns so they're ignored like the rest.