### PR TITLE
ci: make the Docker test matrix resilient to registry flakes (#172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Ride out transient crates.io/registry blips instead of failing the job.
+  CARGO_NET_RETRY: "10"
 
 jobs:
   fmt:
@@ -57,8 +59,23 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
+      # One distro's transient registry timeout must not cancel the others.
+      fail-fast: false
       matrix:
         target: [debian, alpine, fedora]
     steps:
       - uses: actions/checkout@v6
-      - run: docker compose run --rm ${{ matrix.target }} cargo test --workspace
+      # Base images are pulled from Docker Hub at build time; retry to ride
+      # out transient registry timeouts that would otherwise fail the job.
+      - name: Build ${{ matrix.target }} image
+        run: |
+          for attempt in 1 2 3; do
+            docker compose build ${{ matrix.target }} && exit 0
+            echo "::warning::'${{ matrix.target }}' image build attempt $attempt failed (likely a registry timeout); retrying in 30s"
+            sleep 30
+          done
+          exit 1
+      # CARGO_NET_RETRY is passed into the container so cargo retries crate
+      # downloads; a real test failure still fails fast (no step-level retry).
+      - name: Test on ${{ matrix.target }}
+        run: docker compose run --rm -e CARGO_NET_RETRY=10 ${{ matrix.target }} cargo test --workspace


### PR DESCRIPTION
## Summary

The `Test (debian/alpine/fedora)` matrix fails intermittently on transient network errors unrelated to the code. On 2026-06-10 `main` CI for `27daa7b` failed **four times in a row** — Docker Hub base-image pull `i/o timeout` (alpine, then fedora) and a crates.io `curl failed [55] Broken pipe`. The runner-native `Test` job (no Docker pull, cached) passed every time, isolating the cause to the matrix's network exposure.

## Changes (`.github/workflows/ci.yml` only)

- **`fail-fast: false`** on the matrix — one distro's flake no longer cancels the other two.
- **Retry `docker compose build <target>`** (the Docker Hub pull) 3× with 30s backoff.
- **`CARGO_NET_RETRY=10`** — set workflow-wide for runner-native jobs and passed into the container (`-e`) so cargo retries crate downloads. A real test failure still fails fast (no retry wraps the test run).

No new third-party actions; a plain shell retry loop keeps the supply-chain surface unchanged.

## Validation

- YAML parses; verified locally that `docker compose run --rm -e CARGO_NET_RETRY=10 <svc>` propagates the var into the container.
- Note: the matrix is `push`-gated, so it does not execute on this PR — it runs on merge to `main`. The retry/back-off logic is plain shell and reviewed inline.

Closes #172.