### PR TITLE
ci: polish the image-build retry loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,14 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             docker compose build ${{ matrix.target }} && exit 0
-            echo "::warning::'${{ matrix.target }}' image build attempt $attempt failed (likely a registry timeout); retrying in 30s"
-            sleep 30
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::'${{ matrix.target }}' image build attempt $attempt failed (likely a registry timeout); retrying in 30s"
+              sleep 30
+            fi
           done
           exit 1
-      # CARGO_NET_RETRY is passed into the container so cargo retries crate
-      # downloads; a real test failure still fails fast (no step-level retry).
+      # Forward the workflow-wide CARGO_NET_RETRY into the container (single
+      # source of truth) so cargo retries crate downloads; a real test failure
+      # still fails fast (no step-level retry).
       - name: Test on ${{ matrix.target }}
-        run: docker compose run --rm -e CARGO_NET_RETRY=10 ${{ matrix.target }} cargo test --workspace
+        run: docker compose run --rm -e CARGO_NET_RETRY ${{ matrix.target }} cargo test --workspace


### PR DESCRIPTION
Follow-up addressing the two Copilot comments on #173:

- **No sleep after the last attempt** — the retry loop slept 30s even after the 3rd/final failed build, padding already-failing runs. Now gated to `attempt < 3`.
- **Single source of truth for `CARGO_NET_RETRY`** — the container run hard-coded `-e CARGO_NET_RETRY=10`, duplicating the workflow-wide `env` value. Now forwards the existing var with a bare `-e CARGO_NET_RETRY`.

Verified locally: YAML parses; `-e CARGO_NET_RETRY` propagates the workflow value into the container.

Refs #172, #173.