### PR TITLE
docker: install cargo-deny as a pinned prebuilt binary

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -19,8 +19,19 @@ RUN apk add --no-cache \
     curl
 
 RUN rustup component add clippy rustfmt \
-    && cargo install cargo-deny \
     && curl -LsSf https://get.nexte.st/latest/linux-musl | tar zxf - -C /usr/local/cargo/bin
+
+# cargo-deny: pinned, checksum-verified prebuilt binary. The static musl build
+# runs on glibc too, so every image shares one asset. Installing the binary
+# (instead of `cargo install cargo-deny`) skips a multi-minute source compile.
+ARG CARGO_DENY_VERSION=0.19.8
+ARG CARGO_DENY_SHA256=70e769ae3872e34d45132b17040859175e11401dc12dddb0303e0b8c7d088f3f
+RUN curl -LsSf "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o /tmp/cargo-deny.tar.gz \
+    && echo "${CARGO_DENY_SHA256}  /tmp/cargo-deny.tar.gz" | sha256sum -c - \
+    && tar zxf /tmp/cargo-deny.tar.gz -C /tmp \
+    && install -m 0755 "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny" /usr/local/cargo/bin/cargo-deny \
+    && rm -rf /tmp/cargo-deny.tar.gz "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl" \
+    && cargo-deny --version
 
 RUN adduser -D -s /bin/bash testuser \
     && adduser -D -s /bin/sh testuser2 \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -16,8 +16,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup component add clippy rustfmt \
-    && cargo install cargo-deny \
     && curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/cargo/bin
+
+# cargo-deny: pinned, checksum-verified prebuilt binary. The static musl build
+# runs on glibc too, so every image shares one asset. Installing the binary
+# (instead of `cargo install cargo-deny`) skips a multi-minute source compile.
+ARG CARGO_DENY_VERSION=0.19.8
+ARG CARGO_DENY_SHA256=70e769ae3872e34d45132b17040859175e11401dc12dddb0303e0b8c7d088f3f
+RUN curl -LsSf "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o /tmp/cargo-deny.tar.gz \
+    && echo "${CARGO_DENY_SHA256}  /tmp/cargo-deny.tar.gz" | sha256sum -c - \
+    && tar zxf /tmp/cargo-deny.tar.gz -C /tmp \
+    && install -m 0755 "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny" /usr/local/cargo/bin/cargo-deny \
+    && rm -rf /tmp/cargo-deny.tar.gz "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl" \
+    && cargo-deny --version
 
 RUN useradd -m -s /bin/bash testuser \
     && useradd -m -s /bin/sh testuser2 \

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -24,8 +24,19 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     --component clippy,rustfmt
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN cargo install cargo-deny \
-    && curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /root/.cargo/bin
+RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /root/.cargo/bin
+
+# cargo-deny: pinned, checksum-verified prebuilt binary. The static musl build
+# runs on glibc too, so every image shares one asset. Installing the binary
+# (instead of `cargo install cargo-deny`) skips a multi-minute source compile.
+ARG CARGO_DENY_VERSION=0.19.8
+ARG CARGO_DENY_SHA256=70e769ae3872e34d45132b17040859175e11401dc12dddb0303e0b8c7d088f3f
+RUN curl -LsSf "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o /tmp/cargo-deny.tar.gz \
+    && echo "${CARGO_DENY_SHA256}  /tmp/cargo-deny.tar.gz" | sha256sum -c - \
+    && tar zxf /tmp/cargo-deny.tar.gz -C /tmp \
+    && install -m 0755 "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny" /root/.cargo/bin/cargo-deny \
+    && rm -rf /tmp/cargo-deny.tar.gz "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl" \
+    && cargo-deny --version
 
 RUN useradd -m -s /bin/bash testuser \
     && useradd -m -s /bin/sh testuser2 \


### PR DESCRIPTION
## Summary

The dev images built cargo-deny from source (`cargo install cargo-deny`). That recompiled it on every image build (several minutes ×3) and surfaced cargo-deny's **own** `profile.dev.package.{insta,similar}` warnings during the build:

```
warning: profile package spec `insta` in profile `dev` did not match any packages
warning: profile package spec `similar` in profile `dev` did not match any packages
```

Those look like *our* config but aren't — they're in [cargo-deny's Cargo.toml](https://github.com/EmbarkStudios/cargo-deny/blob/main/Cargo.toml) (insta is its snapshot-test dep), emitted because `cargo install` resolves without dev-deps.

## Change

Install the **pinned, checksum-verified prebuilt** cargo-deny binary instead (all three Dockerfiles). The static-musl build runs on glibc too, so one asset serves debian/alpine/fedora.

- No source compile → **faster image builds** and **no spurious warnings**.
- **Reproducible**: sha256-verified, version pinned via `ARG` (Renovate-trackable) — an improvement over the previous unpinned `cargo install`.
- Each build self-validates with `cargo-deny --version`.

## Validation

Built **all three images locally** — debian (glibc), alpine (musl/busybox), fedora (glibc/dnf):
- `/tmp/cargo-deny.tar.gz: OK` (checksum) on each
- `cargo-deny 0.19.8` runs on each (confirms the static binary works across libc)
- the `insta`/`similar` warnings are gone

Note: the CI `Cargo Deny` gate uses `EmbarkStudios/cargo-deny-action` and is unaffected; this only changes the local/dev Docker images.