### PR TITLE
deps: bump uucore from 0.8 to 0.9 (#179)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,13 +986,12 @@ dependencies = [
 
 [[package]]
 name = "uucore"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d779636d827cde4100f0e65ff3fd23b0b1f1195055475c6e6813d425f30c8e"
+checksum = "069b34217c27f611e1589f540f58118dbf226a9e407d38ab472052ff075a1dc2"
 dependencies = [
  "clap",
  "fluent",
- "fluent-bundle",
  "fluent-syntax",
  "nix",
  "os_display",
@@ -1006,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "uucore_procs"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da865e8a648b260dbd89fca76d0801995877ab27a4e259b6dec30ba9743b86ab"
+checksum = "34337da211e7abfff7189b794afb3b5018fe356fb36474b73645458fc1201350"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete = "4"
 
 # uutils integration
-uucore = "0.8"
+uucore = "0.9"
 
 # Error handling
 thiserror = "2"


### PR DESCRIPTION
## Summary

Raise `uucore` from 0.8 to 0.9 as requested in #179. This unblocks the newer uucore helpers and is the prerequisite for the #181 boilerplate dedup.

- **Zero API drift** — our uucore surface (`show_error!`/`show_warning!`, `uucore::error`, `#[uucore::main]`, `uucore::bin!`, `util_name`) is unchanged between 0.8 and 0.9; no source changes needed.
- **MSRV compatible** — uucore 0.9 requires Rust 1.88; our gate is 1.94.
- Note: Renovate's own 0.9 bump (#166) was closed during dependency-update cleanup, which makes Renovate ignore the 0.9 line permanently — hence this manual bump.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green on **Debian**
- [x] `cargo test --workspace` — green on **Alpine (musl)** and **Fedora** locally (59 passing suites each; the Docker matrix is push-gated and skipped on PRs)

Closes #179.