### PR TITLE
shadow-core, tools: de-duplicate the clap-error boilerplate (#181)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
 name = "shadow-core"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "landlock",
  "libc",
  "proptest",
@@ -662,6 +663,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror",
+ "uucore",
  "zeroize",
 ]
 

--- a/src/shadow-core/Cargo.toml
+++ b/src/shadow-core/Cargo.toml
@@ -15,9 +15,11 @@ description = "shadow-core ~ (shadow-rs) parsers, atomic file ops, locking, PAM"
 path = "src/lib.rs"
 
 [dependencies]
+clap = { workspace = true }
 libc = { workspace = true }
 rustix = { workspace = true }
 thiserror = { workspace = true }
+uucore = { workspace = true }
 zeroize = { workspace = true }
 subtle = { workspace = true }
 landlock = { workspace = true, optional = true }

--- a/src/shadow-core/src/cli.rs
+++ b/src/shadow-core/src/cli.rs
@@ -3,10 +3,17 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-//! Common CLI strings advertising shadow-rs as part of the uutils project.
+//! Common CLI plumbing shared by every shadow-rs tool.
 //!
-//! These are appended to every tool's clap [`Command`] so that `--help` and
-//! `--version` make the project origin explicit (issue #161).
+//! Identification strings appended to every tool's clap [`Command`] so that
+//! `--help` and `--version` make the project origin explicit (issue #161),
+//! plus the shared clap-error → exit-code handling that each `uumain` used
+//! to copy-paste (issue #181).
+
+use std::ffi::OsString;
+use std::fmt;
+
+use uucore::error::{UError, UResult};
 
 /// Suffix used as the clap version string. clap renders `--version` as
 /// `<bin> <version>`, so `passwd --version` prints `passwd (uutils shadow-rs) <ver>`.
@@ -14,3 +21,94 @@ pub const VERSION: &str = concat!("(uutils shadow-rs) ", env!("CARGO_PKG_VERSION
 
 /// Footer appended to `--help` to identify the project.
 pub const AFTER_HELP: &str = "Part of the uutils project: https://github.com/uutils/shadow-rs";
+
+/// Error whose message has already been written to the terminal; it carries
+/// only the exit code.
+///
+/// `Display` is intentionally empty so the uucore wrapper does not print a
+/// second message on top of what clap (or the tool) already emitted.
+#[derive(Debug)]
+pub struct AlreadyPrinted(pub i32);
+
+impl fmt::Display for AlreadyPrinted {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+impl std::error::Error for AlreadyPrinted {}
+
+impl UError for AlreadyPrinted {
+    fn code(&self) -> i32 {
+        self.0
+    }
+}
+
+/// Parse `args` against the tool's clap `Command`, mapping a parse failure to
+/// the tool's syntax-error exit code via `code`.
+///
+/// Returns `Ok(None)` when clap already handled the invocation itself
+/// (`--help`/`--version`, printed to stdout): the tool should exit 0. On a
+/// real parse error the message is printed to stderr and the returned error
+/// carries `code(&err)`.
+pub fn parse_args(
+    cmd: clap::Command,
+    args: impl IntoIterator<Item = OsString>,
+    code: impl FnOnce(&clap::Error) -> i32,
+) -> UResult<Option<clap::ArgMatches>> {
+    match cmd.try_get_matches_from(args) {
+        Ok(matches) => Ok(Some(matches)),
+        Err(e) => {
+            e.print().ok();
+            if e.use_stderr() {
+                Err(AlreadyPrinted(code(&e)).into())
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn demo_cmd() -> clap::Command {
+        clap::Command::new("demo").arg(
+            clap::Arg::new("flag")
+                .long("flag")
+                .action(clap::ArgAction::SetTrue),
+        )
+    }
+
+    #[test]
+    fn already_printed_has_empty_display_and_carries_code() {
+        let err = AlreadyPrinted(7);
+        assert_eq!(err.to_string(), "");
+        assert_eq!(err.code(), 7);
+    }
+
+    #[test]
+    fn parse_args_returns_matches_on_success() {
+        let args = ["demo", "--flag"].map(OsString::from);
+        let matches = parse_args(demo_cmd(), args, |_| 2)
+            .expect("should parse")
+            .expect("should yield matches");
+        assert!(matches.get_flag("flag"));
+    }
+
+    #[test]
+    fn parse_args_maps_errors_through_code() {
+        let args = ["demo", "--no-such-flag"].map(OsString::from);
+        let err = parse_args(demo_cmd(), args, |_| 42).expect_err("should fail");
+        assert_eq!(err.code(), 42);
+    }
+
+    #[test]
+    fn parse_args_handles_version_as_none() {
+        let cmd = demo_cmd().version("1.0").disable_help_flag(false);
+        let args = ["demo", "--version"].map(OsString::from);
+        let result = parse_args(cmd, args, |_| 2).expect("--version is not an error");
+        assert!(result.is_none());
+    }
+}

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -64,8 +64,6 @@ enum ChageError {
     FileBusy(String),
     /// Exit 15 — shadow entry not found for user.
     ShadowNotFound(String),
-    /// Sentinel used when the error has already been printed (e.g. by clap).
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for ChageError {
@@ -75,7 +73,6 @@ impl fmt::Display for ChageError {
             | Self::UnexpectedFailure(msg)
             | Self::FileBusy(msg)
             | Self::ShadowNotFound(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -89,7 +86,6 @@ impl UError for ChageError {
             Self::UnexpectedFailure(_) => 3,
             Self::FileBusy(_) => 5,
             Self::ShadowNotFound(_) => 15,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -228,15 +224,8 @@ fn format_date_human(days: i64) -> String {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(ChageError::AlreadyPrinted(2).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
+        return Ok(());
     };
 
     // Handle --root / -R: chroot before anything else.
@@ -249,7 +238,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // The LOGIN argument is required by clap.
     let login = matches
         .get_one::<String>(options::LOGIN)
-        .ok_or(ChageError::AlreadyPrinted(2))?;
+        .ok_or(shadow_core::cli::AlreadyPrinted(2))?;
 
     let is_list = matches.get_flag(options::LIST);
 
@@ -945,7 +934,7 @@ mod tests {
             exit_codes::SHADOW_NOT_FOUND
         );
         assert_eq!(
-            ChageError::AlreadyPrinted(exit_codes::INVALID_SYNTAX).code(),
+            shadow_core::cli::AlreadyPrinted(exit_codes::INVALID_SYNTAX).code(),
             exit_codes::INVALID_SYNTAX
         );
     }
@@ -958,7 +947,7 @@ mod tests {
         let err = ChageError::ShadowNotFound("no entry".into());
         assert_eq!(format!("{err}"), "no entry");
 
-        let err = ChageError::AlreadyPrinted(2);
+        let err = shadow_core::cli::AlreadyPrinted(2);
         assert_eq!(format!("{err}"), "");
     }
 

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -38,15 +38,12 @@ mod options {
 enum ChfnError {
     /// Exit 1 — insufficient privileges or general error.
     Error(String),
-    /// Sentinel for errors already printed by clap.
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for ChfnError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Error(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -57,7 +54,6 @@ impl UError for ChfnError {
     fn code(&self) -> i32 {
         match self {
             Self::Error(_) => 1,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -226,15 +222,8 @@ where
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(ChfnError::AlreadyPrinted(1).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+        return Ok(());
     };
 
     // Handle --root / -R: chroot before anything else.

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -47,8 +47,6 @@ enum ChpasswdError {
     FileBusy(String),
     /// Exit 1 — invalid input line.
     InvalidInput(String),
-    /// Sentinel used when the error has already been printed (e.g. by clap).
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for ChpasswdError {
@@ -58,7 +56,6 @@ impl fmt::Display for ChpasswdError {
             | Self::UnexpectedFailure(msg)
             | Self::FileBusy(msg)
             | Self::InvalidInput(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -72,7 +69,6 @@ impl UError for ChpasswdError {
             | Self::UnexpectedFailure(_)
             | Self::FileBusy(_)
             | Self::InvalidInput(_) => 1,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -166,15 +162,8 @@ fn days_since_epoch() -> Result<i64, ChpasswdError> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(ChpasswdError::AlreadyPrinted(1).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+        return Ok(());
     };
 
     // Handle --root / -R: chroot before anything else.
@@ -602,8 +591,8 @@ mod tests {
     fn test_already_printed_preserves_code() {
         use uucore::error::UError;
 
-        assert_eq!(ChpasswdError::AlreadyPrinted(1).code(), 1);
-        assert_eq!(ChpasswdError::AlreadyPrinted(2).code(), 2);
+        assert_eq!(shadow_core::cli::AlreadyPrinted(1).code(), 1);
+        assert_eq!(shadow_core::cli::AlreadyPrinted(2).code(), 2);
     }
 
     #[test]
@@ -614,7 +603,7 @@ mod tests {
         let err = ChpasswdError::InvalidInput("bad line".into());
         assert_eq!(format!("{err}"), "bad line");
 
-        let err = ChpasswdError::AlreadyPrinted(1);
+        let err = shadow_core::cli::AlreadyPrinted(1);
         assert_eq!(format!("{err}"), "");
     }
 

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -37,15 +37,12 @@ mod options {
 enum ChshError {
     /// Exit 1 — general error.
     Error(String),
-    /// Sentinel for errors already printed by clap.
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for ChshError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Error(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -56,7 +53,6 @@ impl UError for ChshError {
     fn code(&self) -> i32 {
         match self {
             Self::Error(_) => 1,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -240,15 +236,8 @@ where
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(ChshError::AlreadyPrinted(1).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+        return Ok(());
     };
 
     // Handle --root / -R: chroot before anything else.

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -52,7 +52,6 @@ enum GroupaddError {
     GidInUse(String),
     GroupInUse(String),
     CantUpdate(String),
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for GroupaddError {
@@ -63,7 +62,6 @@ impl fmt::Display for GroupaddError {
             | Self::GidInUse(msg)
             | Self::GroupInUse(msg)
             | Self::CantUpdate(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -78,7 +76,6 @@ impl UError for GroupaddError {
             Self::GidInUse(_) => exit_codes::GID_IN_USE,
             Self::GroupInUse(_) => exit_codes::GROUP_IN_USE,
             Self::CantUpdate(_) => exit_codes::CANT_UPDATE,
-            Self::AlreadyPrinted(c) => *c,
         }
     }
 }
@@ -97,20 +94,14 @@ impl UError for GroupaddError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(GroupaddError::AlreadyPrinted(exit_codes::BAD_SYNTAX).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::BAD_SYNTAX)?
+    else {
+        return Ok(());
     };
 
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("Permission denied.");
-        return Err(GroupaddError::AlreadyPrinted(1).into());
+        return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 
     do_groupadd(&matches)

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -42,7 +42,6 @@ enum GroupdelError {
     GroupNotFound(String),
     PrimaryGroup(String),
     CantUpdate(String),
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for GroupdelError {
@@ -52,7 +51,6 @@ impl fmt::Display for GroupdelError {
             | Self::GroupNotFound(msg)
             | Self::PrimaryGroup(msg)
             | Self::CantUpdate(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -66,7 +64,6 @@ impl UError for GroupdelError {
             Self::GroupNotFound(_) => exit_codes::GROUP_NOT_FOUND,
             Self::PrimaryGroup(_) => exit_codes::PRIMARY_GROUP,
             Self::CantUpdate(_) => exit_codes::CANT_UPDATE,
-            Self::AlreadyPrinted(c) => *c,
         }
     }
 }
@@ -85,20 +82,14 @@ impl UError for GroupdelError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(GroupdelError::AlreadyPrinted(exit_codes::BAD_SYNTAX).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::BAD_SYNTAX)?
+    else {
+        return Ok(());
     };
 
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("Permission denied.");
-        return Err(GroupdelError::AlreadyPrinted(1).into());
+        return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 
     let group_name = matches

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -49,7 +49,6 @@ enum GroupmodError {
     GroupNotFound(String),
     NameInUse(String),
     CantUpdate(String),
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for GroupmodError {
@@ -61,7 +60,6 @@ impl fmt::Display for GroupmodError {
             | Self::GroupNotFound(msg)
             | Self::NameInUse(msg)
             | Self::CantUpdate(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -77,7 +75,6 @@ impl UError for GroupmodError {
             Self::GroupNotFound(_) => exit_codes::GROUP_NOT_FOUND,
             Self::NameInUse(_) => exit_codes::NAME_IN_USE,
             Self::CantUpdate(_) => exit_codes::CANT_UPDATE,
-            Self::AlreadyPrinted(c) => *c,
         }
     }
 }
@@ -97,20 +94,14 @@ impl UError for GroupmodError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(GroupmodError::AlreadyPrinted(exit_codes::BAD_SYNTAX).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::BAD_SYNTAX)?
+    else {
+        return Ok(());
     };
 
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("Permission denied.");
-        return Err(GroupmodError::AlreadyPrinted(1).into());
+        return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 
     let group_name = matches

--- a/src/uu/newgrp/src/newgrp.rs
+++ b/src/uu/newgrp/src/newgrp.rs
@@ -34,15 +34,12 @@ mod options {
 enum NewgrpError {
     /// Exit 1 — general error.
     Error(String),
-    /// Sentinel for errors already printed by clap.
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for NewgrpError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Error(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -53,7 +50,6 @@ impl UError for NewgrpError {
     fn code(&self) -> i32 {
         match self {
             Self::Error(_) => 1,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -222,15 +218,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     shadow_core::hardening::suppress_core_dumps();
     let _clean_env = shadow_core::hardening::sanitized_env();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(NewgrpError::AlreadyPrinted(1).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+        return Ok(());
     };
 
     let root = SysRoot::default();

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -62,8 +62,9 @@ mod exit_codes {
 ///   1 = permission denied, 3 = unexpected failure, 4 = shadow file missing,
 ///   5 = file busy (lock), 10 = PAM error.
 ///
-/// For clap-reported errors (exit 2 or 6), use [`AlreadyPrinted`] so the
-/// uucore wrapper does not duplicate the message clap already wrote.
+/// Clap-reported errors (exit 2 or 6) go through
+/// [`shadow_core::cli::AlreadyPrinted`] so the uucore wrapper does not
+/// duplicate the message clap already wrote.
 #[derive(Debug)]
 enum PasswdError {
     /// Exit 1 — insufficient privileges.
@@ -77,9 +78,6 @@ enum PasswdError {
     /// Exit 10 — PAM returned an error.
     #[cfg_attr(not(feature = "pam"), allow(dead_code))]
     PamError(String),
-    /// Sentinel used when the error has already been printed (e.g. by clap).
-    /// The uucore wrapper skips printing when Display yields an empty string.
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for PasswdError {
@@ -90,7 +88,6 @@ impl fmt::Display for PasswdError {
             | Self::FileMissing(msg)
             | Self::FileBusy(msg)
             | Self::PamError(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -105,7 +102,6 @@ impl UError for PasswdError {
             Self::FileMissing(_) => 4,
             Self::FileBusy(_) => 5,
             Self::PamError(_) => 10,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -147,23 +143,14 @@ fn apply_landlock(root: &SysRoot) {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                // --help / --version: clap prints to stdout, exit 0.
-                return Ok(());
-            }
-            // GNU passwd exits 2 for conflicting options, 6 for unknown/invalid.
-            return Err(match e.kind() {
-                clap::error::ErrorKind::ArgumentConflict
-                | clap::error::ErrorKind::MissingRequiredArgument => {
-                    PasswdError::AlreadyPrinted(2).into()
-                }
-                _ => PasswdError::AlreadyPrinted(6).into(),
-            });
-        }
+    // GNU passwd exits 2 for conflicting options, 6 for unknown/invalid.
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |e| match e.kind() {
+        clap::error::ErrorKind::ArgumentConflict
+        | clap::error::ErrorKind::MissingRequiredArgument => 2,
+        _ => 6,
+    })?
+    else {
+        return Ok(());
     };
 
     // Handle --root / -R: chroot before anything else.

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -106,8 +106,6 @@ enum UseraddError {
     CannotUpdateGroup(String),
     /// Exit 12 -- cannot create home directory.
     CannotCreateHome(String),
-    /// Sentinel used when the error has already been printed (e.g. by clap).
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for UseraddError {
@@ -121,7 +119,6 @@ impl fmt::Display for UseraddError {
             | Self::UsernameInUse(msg)
             | Self::CannotUpdateGroup(msg)
             | Self::CannotCreateHome(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -139,7 +136,6 @@ impl UError for UseraddError {
             Self::UsernameInUse(_) => 9,
             Self::CannotUpdateGroup(_) => 10,
             Self::CannotCreateHome(_) => 12,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -271,27 +267,14 @@ fn today_days_since_epoch() -> Result<i64, UseraddError> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(match e.kind() {
-                clap::error::ErrorKind::ArgumentConflict
-                | clap::error::ErrorKind::MissingRequiredArgument => {
-                    UseraddError::AlreadyPrinted(2).into()
-                }
-                _ => UseraddError::AlreadyPrinted(2).into(),
-            });
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
+        return Ok(());
     };
 
     // Only root can add users.
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("Permission denied.");
-        return Err(UseraddError::AlreadyPrinted(1).into());
+        return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 
     // Handle --defaults mode (show defaults and exit).

--- a/src/uu/userdel/src/userdel.rs
+++ b/src/uu/userdel/src/userdel.rs
@@ -38,12 +38,14 @@ mod exit_codes {
     pub const CANT_REMOVE_HOME: i32 = 12;
 }
 
+// Variant names mirror GNU userdel(8)'s documented exit-code names
+// (CANT_UPDATE_PASSWD, ...), so the shared prefix is intentional.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 enum UserdelError {
     CantUpdatePasswd(String),
     CantUpdateGroup(String),
     CantRemoveHome(String),
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for UserdelError {
@@ -52,7 +54,6 @@ impl fmt::Display for UserdelError {
             Self::CantUpdatePasswd(msg)
             | Self::CantUpdateGroup(msg)
             | Self::CantRemoveHome(msg) => f.write_str(msg),
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -65,7 +66,6 @@ impl UError for UserdelError {
             Self::CantUpdatePasswd(_) => exit_codes::CANT_UPDATE_PASSWD,
             Self::CantUpdateGroup(_) => exit_codes::CANT_UPDATE_GROUP,
             Self::CantRemoveHome(_) => exit_codes::CANT_REMOVE_HOME,
-            Self::AlreadyPrinted(code) => *code,
         }
     }
 }
@@ -74,19 +74,14 @@ impl UError for UserdelError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _ = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(UserdelError::AlreadyPrinted(exit_codes::INVALID_SYNTAX).into());
-        }
+    let Some(matches) =
+        shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::INVALID_SYNTAX)?
+    else {
+        return Ok(());
     };
 
     let Some(login) = matches.get_one::<String>(options::LOGIN) else {
-        return Err(UserdelError::AlreadyPrinted(exit_codes::INVALID_SYNTAX).into());
+        return Err(shadow_core::cli::AlreadyPrinted(exit_codes::INVALID_SYNTAX).into());
     };
     let remove_home = matches.get_flag(options::REMOVE);
     let prefix = matches

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -46,7 +46,6 @@ enum UsermodError {
     CantUpdate(String),
     UserNotFound(String),
     UidInUse(String),
-    AlreadyPrinted(i32),
 }
 
 impl fmt::Display for UsermodError {
@@ -55,7 +54,6 @@ impl fmt::Display for UsermodError {
             Self::CantUpdate(msg) | Self::UserNotFound(msg) | Self::UidInUse(msg) => {
                 f.write_str(msg)
             }
-            Self::AlreadyPrinted(_) => Ok(()),
         }
     }
 }
@@ -68,7 +66,6 @@ impl UError for UsermodError {
             Self::CantUpdate(_) => 1,
             Self::UserNotFound(_) => 6,
             Self::UidInUse(_) => 4,
-            Self::AlreadyPrinted(c) => *c,
         }
     }
 }
@@ -78,19 +75,12 @@ impl UError for UsermodError {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _ = shadow_core::hardening::harden_process();
 
-    let matches = match uu_app().try_get_matches_from(args) {
-        Ok(m) => m,
-        Err(e) => {
-            e.print().ok();
-            if !e.use_stderr() {
-                return Ok(());
-            }
-            return Err(UsermodError::AlreadyPrinted(2).into());
-        }
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
+        return Ok(());
     };
 
     let Some(login) = matches.get_one::<String>(options::USER) else {
-        return Err(UsermodError::AlreadyPrinted(2).into());
+        return Err(shadow_core::cli::AlreadyPrinted(2).into());
     };
     let prefix = matches
         .get_one::<String>(options::PREFIX)


### PR DESCRIPTION
## Summary

Implements #181: hoists the copy-pasted clap-error handling out of all 12 tool crates into `shadow-core`.

**New shared plumbing** (`shadow_core::cli`, unit-tested):
- `AlreadyPrinted(i32)` — shared `UError` whose `Display` is empty (message already printed); carries only the exit code.
- `parse_args(cmd, args, code)` — parses argv, prints the clap error, returns `Ok(None)` for `--help`/`--version` (exit 0), and maps real parse failures through the tool's `code` function.

**Per tool** (chage, chfn, chpasswd, chsh, groupadd, groupdel, groupmod, newgrp, passwd, useradd, userdel, usermod):
- The 10-line `try_get_matches_from` match collapses to one `let Some(matches) = parse_args(...)? else { return Ok(()); }`.
- The `AlreadyPrinted(i32)` variant and its identical `Display`/`code()` arms are deleted from every enum; non-clap uses of the sentinel switch to the shared type.
- `grpck`/`pwck` (plain `?`) are unchanged. Net: **−180/+153 lines** with 12 enums simplified.

## Behavior preserved (verified, not assumed)

Ran the built binaries before/after:
| Invocation | Exit code |
|---|---|
| `passwd --help` / `--version` | 0, output byte-identical (`passwd (uutils shadow-rs) 0.2.0`) |
| `passwd --bogus` | 6 (kind-dependent mapping kept) |
| `passwd -l -u` (conflict) | 2 |
| `chpasswd --bogus` | 1 |
| `groupadd --bogus` / missing arg | 2 |

Notes:
- `useradd`'s clap match had two arms that both returned 2 — collapsed to the constant (no behavior change).
- `userdel`'s remaining variants all share the `Cant` prefix, tripping `clippy::enum_variant_names`; allowed with a comment since the names mirror `userdel(8)`'s documented exit-code names.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green on **Debian**
- [x] `cargo test --workspace` — green on **Alpine (musl)** and **Fedora** (59 passing suites each; matrix is push-gated on PRs)
- [x] New unit tests for `AlreadyPrinted` (empty Display, code passthrough) and `parse_args` (success / error mapping / `--version` → `Ok(None)`)

Closes #181.