### PR TITLE
cargo: rename package to uu_shadow. shadow-rs is already used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,31 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shadow-rs"
-version = "0.2.0"
-dependencies = [
- "clap",
- "clap_complete",
- "rustix",
- "shadow-core",
- "tempfile",
- "uu_chage",
- "uu_chfn",
- "uu_chpasswd",
- "uu_chsh",
- "uu_groupadd",
- "uu_groupdel",
- "uu_groupmod",
- "uu_grpck",
- "uu_newgrp",
- "uu_passwd",
- "uu_pwck",
- "uu_useradd",
- "uu_userdel",
- "uu_usermod",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +937,31 @@ dependencies = [
  "shadow-core",
  "tempfile",
  "uucore",
+]
+
+[[package]]
+name = "uu_shadow"
+version = "0.2.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "rustix",
+ "shadow-core",
+ "tempfile",
+ "uu_chage",
+ "uu_chfn",
+ "uu_chpasswd",
+ "uu_chsh",
+ "uu_groupadd",
+ "uu_groupdel",
+ "uu_groupmod",
+ "uu_grpck",
+ "uu_newgrp",
+ "uu_passwd",
+ "uu_pwck",
+ "uu_useradd",
+ "uu_userdel",
+ "uu_usermod",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # spell-checker:ignore uutils
 
 [package]
-name = "shadow-rs"
+name = "uu_shadow"
 version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS)
 all: build
 
 build:
-	cargo build --release --workspace --bins --exclude shadow-rs
+	cargo build --release --workspace --bins --exclude uu_shadow
 
 build-multicall:
 	cargo build --release --bin shadow-rs


### PR DESCRIPTION
https://crates.io/crates/uu_grep is a precedent